### PR TITLE
Add TOML config file option

### DIFF
--- a/examples/TOMLExample.toml
+++ b/examples/TOMLExample.toml
@@ -1,0 +1,3 @@
+lang = "fr-CA"
+
+output = 'C:\Users\dioio\Desktop\NickProject\tiller\output'

--- a/examples/TOMLExample.toml
+++ b/examples/TOMLExample.toml
@@ -1,3 +1,3 @@
 lang = "fr-CA"
 
-output = 'C:\Users\dioio\Desktop\NickProject\tiller\output'
+output = './output'

--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@ Arguments:
 Options:
   --version, -v  Print the current version of Tiller.
   --help, -h     Show this message and exit.
+  --config, -c   Specify the path to a TOML config file to be used.
   --output, -o   Specify the name of the folder which the generated files will appear.
   --lang, -l    Specify the language of the generated HTML file.\n"""
 
@@ -76,7 +77,7 @@ def main(dir: str, version: Optional[bool] = typer.Option(None, "--version", "-v
     if(os.path.isdir(dir)):
         for file in os.listdir(dir):
             # Added a condition to check for markdown file
-            if(file.split(".")[-1] == ".txt" or file.split(".")[-1] == ".md"):
+            if(file.split(".")[-1] == "txt" or file.split(".")[-1] == "md"):
                 with open(dir + "/" + file, "r") as text_file:
                     text_file = text_file.read()
                     WriteHTML(text_file, file.split(".")[0], output, lang)

--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ import typer
 from typing_extensions import Annotated
 import os
 import markdown
+import tomllib
 
 __version__ = "0.1.0"
 __help__ = """Usage: main.py [OPTIONS] DIR \n
@@ -44,8 +45,24 @@ def help_callback(value: bool):
 @app.command()
 def main(dir: str, version: Optional[bool] = typer.Option(None, "--version", "-v", callback=version_callback, help="Print the current version of Tiller."), 
          help: Optional[bool] = typer.Option(None, "--help", "-h", callback=help_callback, help="Print the help message."), output: Optional[str] = typer.Option(None, "--output", "-o", help="Change the output directory of the .html files."),
-         lang: Optional[str] = typer.Option(None, "--lang", "-l", help="Specify the language of the generated HTML file.")):
+         lang: Optional[str] = typer.Option(None, "--lang", "-l", help="Specify the language of the generated HTML file."), config: Optional[str] = typer.Option(None, "--config", "-c", help="Specify the path to a TOML config file.")):
     """Convert .txt or .md files to .html files."""
+    if(config is not None):
+       try:
+           with open(config, "rb") as configFile:
+               data = tomllib.load(configFile)
+               if data.get("o"):
+                   output = data.get("o")
+               if data.get("output"):
+                   output = data.get("output")
+               if data.get("l"):
+                   lang = data.get("l")
+               if data.get("lang"):
+                   lang = data.get("lang")
+       except tomllib.TOMLDecodeError as error:
+           print(error)
+           print("Error: Please provide a valid config TOML file.")
+           exit(-1)
     if(output == None):
         output = "til"
     if(lang == None):


### PR DESCRIPTION
Added the feature that allows the user to provide all their optional arguments as a TOML configuration file. The user can provide the output directory option by including the key: output/o, and language by using the key: lang/l in their TOML config file. The program also exits with correct error messages and codes if the TOML file provided is not valid. Additionally, if there are optional arguments provided in the TOML file that the program does not support, they are ignored. Fixes #19 